### PR TITLE
#175743330 ft(notification): add notification on request

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -92,5 +92,8 @@
 	"Room Id is already occupied!": "Room Id is already occupied!",
 	"No request found!": "No request found!",
 	"Manager Id does not exist.": "Manager Id does not exist.",
-	"User does not exist.": "User does not exist."
+	"User does not exist.": "User does not exist.",
+	"All received notifications": "All received notifications",
+	"No notifications yet": "No notifications yet",
+	"All received notification": "All received notification"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -71,5 +71,7 @@
 	"Bad request":"Mauvaise demande",
 	"Facility Not found!":"Installation introuvable!",
 	"Internal error":"Erreur interne",
-	"Hotel does not exist!": "L'hôtel n'existe pas!"
+	"Hotel does not exist!": "L'hôtel n'existe pas!",
+	"All received notifications": "Toutes les notifications reçues",
+	"No notifications yet": "Pas encore de notifications"
 }

--- a/locales/ki.json
+++ b/locales/ki.json
@@ -59,5 +59,7 @@
 	"Bad request":"Ubusabe bubi",
 	"Facility Not found!":"Ikigo Nticyabonetse!",
 	"Internal error":"Ikosa ryimbere",
-	"Hotel does not exist!": "Hotel ntabwo ibaho!"
+	"Hotel does not exist!": "Hotel ntabwo ibaho!",
+	"All received notifications": "Imenyesha zose zakiriwe",
+	"No notifications yet": "Nta menyesha"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -32,7 +32,6 @@
 	"Please login first!": "Tafadhali ingia kwanza!",
 	"Unauthorized": "Isiyoidhinishwa",
 	"Only super administrator can perform this action!": "Msimamizi mkuu tu ndiye anayeweza kufanya kitendo hiki!",
-	
 	"Facility liked": "Kituo kilipendwa",
 	"Reaction undone": "Majibu yamefutwa",
 	"Facility Liked": "Kituo Unapenda",
@@ -42,12 +41,10 @@
 	"Facility re-unliked": "Kituo hakipendwi",
 	"FacilityId is required": "KituoId kinahitajika",
 	"No facility found": "Hakuna kituo kilichopatikana",
-	
 	"Access denied. You can only update your profile":"Ufikiaji umekataliwa. Unaweza tu kusasisha wasifu wako",
 	"User not found":"Mtumiaji hajapatikana",
 	"Profile not found":"Profaili haipatikani",
 	"Profile saved successfully":"Wasifu umehifadhiwa kwa mafanikio",
-	
 	"Please login!": "Tafadhali ingia!",
 	"No role assigned!": "Hakuna jukumu lililopewa!",
 	"Access denied!": "Ufikiaji umekataliwa!",
@@ -64,5 +61,7 @@
 	"Please login first":"Tafadhali ingia kwanza",
 	"Facility Not found!":"Kituo Haikupatikana!",
 	"Internal error":"Hitilafu ya ndani",
-	"Hotel does not exist!": "Hoteli haipo!"
+	"Hotel does not exist!": "Hoteli haipo!",
+	"All received notifications": "Arifa zote zilizopokelewa",
+	"No notifications yet": "Hakuna arifa bado"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,10 +1216,25 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
       "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ=="
     },
+    "@types/component-emitter": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
+    },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg=="
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog=="
+    },
+    "@types/cors": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.9.tgz",
+      "integrity": "sha512-zurD1ibz21BRlAOIKP8yhrxlqKx6L9VCwkB5kMiP6nZAhoF5MvC7qS1qPA7nRcr1GJolfkQC7/EAL4hdYejLtg=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -1657,6 +1672,16 @@
           }
         }
       }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "bcrypt": {
       "version": "5.0.0",
@@ -2811,6 +2836,48 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+      "requires": {
+        "base64-arraybuffer": "0.1.4"
       }
     },
     "enquirer": {
@@ -7342,6 +7409,67 @@
         }
       }
     },
+    "socket.io": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.1.tgz",
+      "integrity": "sha512-7cBWdsDC7bbyEF6WbBqffjizc/H4YF1wLdZoOzuYfo2uMNSFjJKuQ36t0H40o9B20DO6p+mSytEd92oP4S15bA==",
+      "requires": {
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.8",
+        "@types/node": "^14.14.10",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg=="
+    },
+    "socket.io-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "requires": {
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8404,6 +8532,11 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "pg-hstore": "^2.3.3",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0",
+    "socket.io": "^3.1.1",
     "swagger-jsdoc": "^6.0.0-rc.5",
     "swagger-ui-express": "^4.1.5"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.2/tailwind.min.css" integrity="sha512-+WF6UMXHki/uCy0vATJzyA9EmAcohIQuwpNz0qEO+5UeE5ibPejMRdFuARSrl1trs3skqie0rY/gNiolfaef5w==" crossorigin="anonymous" />
+    <title>Barefoot nomad</title>
+</head>
+<body>
+    <nav class="top-0 w-full flex justify-between items-center px-2 py-3 navbar-expand-lg bg-blue-400 text-white">
+        <div>Barefoot nomad</div>
+        <ul class="flex mr-8">
+            <li>
+                <span>Notifications</span>
+                <button class="h-6 w-6 rounded-full bg-pink-700 text-white "></button>
+            </li>
+        </ul>
+    </nav>
+    <div id="alert" class="container mx-auto mt-10 space-y-5" style="width: 45%;" >
+    </div>
+    <h1 class="text-blue-400  py-20 text-center uppercase"></h1>
+    <form class=" container mx-auto flex  flex-col  items-center bg-green-500 py-5 shadow-2xl" style="width: 500px; height: 150px; margin-left: auto;">
+        <label for="id" class="text-white">Enter your Id</label>
+        <input type="text" name="id" id="userId" style="width: 200px; padding-left: 5px;" class="focus:outline-none">
+        <input type="button"  id="submit" value="send" class="mt-5 mb-2 px-2 rounded hover:bg-pink-700 hover:text-white focus:outline-none ">
+    </form>
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+        const socket = io();
+        let notificationCount = 0
+        const closeBtn = document.querySelector('#alert');
+        const handleClick = () => {
+             closeBtn.classList.add('hidden')
+            }
+        socket.on('welcome', msg => {
+            socket.emit('time delay', Date.now())
+            document.querySelector('h1').innerHTML = msg;
+            document.querySelector('button').textContent = notificationCount;
+        });
+        document.querySelector('#submit').addEventListener('click', (e) => {
+           e.preventDefault();
+           const userId = document.querySelector('input').value;
+           socket.emit('join notification', {id: `notification_${userId}`});
+           document.querySelector('form').reset()
+        })
+        socket.on('approved', notification => {
+            socket.emit('time delay', notification.time)
+            notificationCount += 1;
+            document.querySelector('button').textContent = notificationCount;
+            document.querySelector('#alert').innerHTML = `
+           <div class="flex justify-between text-green-200 shadow-inner rounded p-3 bg-green-600">
+                <p class="self-center">
+                <strong>${notification.message}</strong>
+                <a href="${notification.link}" class="hover:underline text-white cursor-pointer">Click here</a>
+                </p>
+                <strong class="text-xl lighn-center cursor-pointer alert-del" onclick="handleClick()">&times;</strong>
+           </div>
+        `
+        })
+        socket.on('rejected', notification => {
+            socket.emit('time delay', notification.time)
+            notificationCount += 1;
+            document.querySelector('button').textContent = notificationCount;
+            document.querySelector('#alert').innerHTML = `
+            <div class="flex justify-between text-green-200 shadow-inner rounded p-3 bg-green-600">
+                <p class="self-center">
+                <strong>${notification.message}</strong>
+                <a href="${notification.link}" class="hover:underline text-white cursor-pointer">Click here</a>
+                </p>
+                <strong class="text-xl lighn-center cursor-pointer alert-del" onclick="handleClick()">&times;</strong>
+           </div>
+           `
+        })
+        socket.on('pending', notification => {
+            socket.emit('time delay', notification.time)
+            notificationCount += 1;
+            document.querySelector('button').textContent = notificationCount;
+            document.querySelector('#alert').innerHTML = `
+            <div class="flex justify-between text-green-200 shadow-inner rounded p-3 bg-green-600">
+                <p class="self-center">
+                <strong>${notification.message}</strong>
+                <a href="${notification.link}" class="hover:underline text-white cursor-pointer">Click here</a>
+                </p>
+                <strong class="text-xl lighn-center cursor-pointer alert-del" onclick="handleClick()">&times;</strong>
+           </div>
+           `
+        })
+    </script>
+</body>
+</html>

--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-underscore-dangle */
+import models from '../database/models';
+
+const { Notification } = models;
+
+export default {
+  getNotifications: async (req, res) => {
+    try {
+      const { id } = req.userData;
+      const savedNotifications = await Notification.findAll({
+        where: { userId: id }
+      });
+      if (!savedNotifications || savedNotifications.length === 0) {
+        return res.status(404).json({ message: res.__('No notifications yet') });
+      }
+      return res.status(200).json({ message: res.__('All received notifications'), savedNotifications });
+    } catch (error) {
+      return res.status(500).json({ message: res.__('Internal server error!') });
+    }
+  }
+};

--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 /* eslint-disable object-curly-newline */
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
@@ -7,6 +8,7 @@ import hotelService from '../services/hotelService';
 import roomService from '../services/roomService';
 import requestService from '../services/requestService';
 import requestHelper from '../utils/requestHelper';
+import checkRequestAndNotify from '../helpers/checkType';
 
 const { request } = model,
   { findHotelByName } = hotelService,
@@ -79,6 +81,11 @@ export default class requestController {
         dateStart,
         dateEnd
       });
+      const userId = id;
+      const status = savedRequest.dataValues.requestStatus;
+      const reqId = savedRequest.dataValues.id;
+
+      checkRequestAndNotify(status, 'PENDING', userId, reqId, 'Request created', 'Your request has been created');
 
       res.status(201).json({ message: res.__('Request created successfully!'), savedRequest });
     } catch (error) {

--- a/src/database/migrations/20210204161025-create-notification.js
+++ b/src/database/migrations/20210204161025-create-notification.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-unused-vars */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Notifications', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      requestId: { type: Sequelize.INTEGER },
+      userId: { type: Sequelize.INTEGER },
+      title: { type: Sequelize.STRING },
+      message: { type: Sequelize.STRING },
+      link: { type: Sequelize.STRING },
+      status: { type: Sequelize.STRING, defaultValue: 'unread' },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('Notifications');
+  }
+};

--- a/src/database/models/notification.js
+++ b/src/database/models/notification.js
@@ -1,0 +1,32 @@
+/* eslint-disable require-jsdoc */
+/* eslint-disable valid-jsdoc */
+const {
+  Model
+} = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class Notification extends Model {
+    static associate(models) {
+      Notification.belongsTo(models.request, { foreignKey: 'requestId' });
+      Notification.belongsTo(models.User, { foreignKey: 'userId' });
+    }
+  }
+  Notification.init({
+    requestId: DataTypes.INTEGER,
+    userId: DataTypes.INTEGER,
+    title: DataTypes.STRING,
+    message: DataTypes.STRING,
+    link: DataTypes.STRING,
+    status: {
+      type: DataTypes.STRING,
+      defaultValue: 'unread',
+      validate: {
+        isIn: { args: [['unread', 'read']], msg: 'Notification status can either be read or unread' }
+      }
+    }
+  }, {
+    sequelize,
+    modelName: 'Notification',
+  });
+  return Notification;
+};

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -14,6 +14,10 @@ module.exports = (sequelize, DataTypes) => {
         as:'Requester',
         foreignKey:'idUser'
       });
+      request.hasMany(models.Notification, {
+        foreignKey: 'requestId',
+        as: 'notifications'
+      });
     }
   }
   request.init({

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -60,6 +60,10 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
+    User.hasMany(models.Notification, {
+      foreignKey: 'userId',
+      as: 'notifications'
+    });
   };
 
   return User;

--- a/src/helpers/checkType.js
+++ b/src/helpers/checkType.js
@@ -1,0 +1,19 @@
+/* eslint-disable import/no-cycle */
+import { emitEvent } from './events';
+
+const checkRequestAndNotify = (reqStatus, type, userIdK, id, titleMessage, notiMessage) => {
+  if (reqStatus === type) {
+    const notification = {
+      eventType: type,
+      userId: userIdK,
+      requestId: id,
+      title: titleMessage,
+      message: notiMessage,
+      link: `/requests/${id}`,
+      status: 'unread'
+    };
+    emitEvent.emit('notification', notification);
+  }
+};
+
+export default checkRequestAndNotify;

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-cycle */
+import { EventEmitter } from 'events';
+import notificationHelper from './notification.helper';
+
+export const emitEvent = new EventEmitter();
+
+export default () => {
+  emitEvent.on('notification', notificationHelper.sendNotification);
+};

--- a/src/helpers/notification.helper.js
+++ b/src/helpers/notification.helper.js
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-cycle */
+import { io } from '../app';
+import notificationService from '../services/notification';
+
+export default {
+  sendNotification: async ({
+    userId, requestId, title, message, status, eventType, link
+  }) => {
+    try {
+      const notification = {
+        userId, requestId, title, message, status, link
+      };
+      const createdNotif = await notificationService.createNotification(notification);
+
+      notification.id = createdNotif.id;
+      notification.time = Date.now();
+
+      if (eventType === 'PENDING') {
+        io.sockets.in(`notification_${userId}`).emit('pending', notification);
+      }
+      if (eventType === 'APPROVED') {
+        io.sockets.in(`notification_${userId}`).emit('approved', notification);
+      }
+      if (eventType === 'REJECTED') {
+        io.sockets.in(`notification_${userId}`).emit('rejected', notification);
+      }
+      return createdNotif;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
-import  app  from './app';
+import server from './app';
 
 const PORT = process.env.PORT || 5000;
 // eslint-disable-next-line no-console
-app.listen(PORT, () => console.log(`App listening on port ${PORT}`));
+server.listen(PORT, () => console.log(`App listening on port ${PORT}`));
 // eslint-disable-next-line no-console
-

--- a/src/routes/managerRoutes.js
+++ b/src/routes/managerRoutes.js
@@ -1,4 +1,4 @@
-/* eslint-disable object-curly-newline */
+/* eslint-disable import/no-cycle */
 import { Router } from 'express';
 import { authManager } from '../middlewares/authManager';
 import { approveRequestValidation } from '../middlewares/requestValidation';
@@ -7,7 +7,9 @@ import managerController from '../controllers/managerController';
 
 const router = new Router(),
   { createRequest } = requestController,
-  { getAllRequests, getOneRequest, updateRequest, assignManagerId } = managerController;
+  {
+    getAllRequests, getOneRequest, updateRequest, assignManagerId
+  } = managerController;
 
 /**
  * @swagger

--- a/src/routes/notification.js
+++ b/src/routes/notification.js
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import notifications from '../controllers/notification.controller';
+import checkAuth from '../middlewares/check-auth';
+
+const notificationRoutes = new Router();
+
+/**
+ * @swagger
+ * /notifications:
+ *  get:
+ *    tags: [Notifications]
+ *    summary: Get notifications
+ *    description: Authenticated user can get all notifications regarding to his/her requests.
+ *    responses:
+ *      '200':
+ *        description: All recieved notifications.
+ *      '400':
+ *        description: Bad request.
+ *      '500':
+ *        description: Internal server error.
+*/
+notificationRoutes.get('/', checkAuth, notifications.getNotifications);
+
+export default notificationRoutes;

--- a/src/services/notification.js
+++ b/src/services/notification.js
@@ -1,0 +1,13 @@
+import models from '../database/models';
+
+const { Notification } = models;
+
+export default {
+  createNotification: async (notification) => {
+    try {
+      return await Notification.create(notification);
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+};

--- a/src/tests/controllers/notification.test.js
+++ b/src/tests/controllers/notification.test.js
@@ -1,0 +1,63 @@
+import { use, request, expect } from 'chai';
+import http from 'chai-http';
+import models from '../../database/models';
+import app from '../../app';
+
+const { Notification } = models;
+
+use(http);
+
+let token;
+let userId;
+
+describe('Notifications', () => {
+  before(async () => {
+    await request(app)
+      .post('/user/signup')
+      .send({
+        firstname: 'imag',
+        lastname: 'coder',
+        email: 'imag@gmail.com',
+        password: 'thecoder@123'
+      })
+      .then((res) => {
+        token = res.body.token;
+        userId = res.body.user_details.id;
+      })
+      .catch((err) => {
+        throw new Error(err);
+      });
+  });
+  it('should return 404 if no notifications found', (done) => {
+    request(app)
+      .get('/notifications')
+      .set('authorization', token)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).have.status(404);
+        expect(res.body).has.property('message');
+        expect(res.body.message).to.match(/No notifications yet/i);
+        done();
+      });
+  });
+  it('should return all notifications', async () => {
+    await Notification.create({
+      eventType: 'PENDING',
+      userId,
+      requestId: 4,
+      title: 'Created request',
+      message: 'Your request was created',
+      link: '/requests/1',
+      status: 'unread'
+    });
+    request(app)
+      .get('/notifications')
+      .set('authorization', token)
+      .end((err, res) => {
+        if (err) return err;
+        expect(res).have.status(200);
+        expect(res.body).has.property('message');
+        expect(res.body.message).to.match(/All received notifications/i);
+      });
+  });
+});

--- a/src/tests/hotelModels.test.js
+++ b/src/tests/hotelModels.test.js
@@ -1,8 +1,6 @@
 import chai from 'chai';
-
 import http from 'chai-http';
 import jwt from 'jsonwebtoken';
-
 import app from '../app';
 
 const { expect } = chai;
@@ -21,9 +19,6 @@ describe('Testing hotel endpoints', () => {
       password: 'furebo@#'
     };
     token = `JWT ${jwt.sign(JSON.parse(JSON.stringify(user)), process.env.JWT_KEY, { expiresIn: '1h' })}`;
-    jwt.verify(token, process.env.JWT_KEY, (err, data) => {
-      console.log(err, data);
-    });
   });
   describe('Getting hotels', () => {
     it('should return all hotels', (done) => {
@@ -63,7 +58,6 @@ describe('Testing hotel endpoints', () => {
 });
 
 describe(' Returning selected hotel', () => {
-  // const id = hotelId;
   it('should return selected hotel', (done) => {
     chai
       .request(app)
@@ -77,7 +71,6 @@ describe(' Returning selected hotel', () => {
 });
 
 describe(' Update selected hotel', () => {
-  // const id = hotelId;
   it('should update a hotel', (done) => {
     chai
       .request(app)
@@ -102,4 +95,38 @@ describe(' Update selected hotel', () => {
       });
   });
 });
-
+describe(' Delete selected hotel', () => {
+  after((done) => {
+    chai.request(app)
+      .post('/hotels')
+      .set('authorization', token)
+      .send({
+        hotelname: 'Serena Hotel',
+        pricerange: '$80',
+        location: 'Gisenyi',
+        ranking: '3 star',
+        parking: 'Yes',
+        wifi: 'Yes',
+        swimmingpool: 'no',
+        breakfast: 'Yes',
+        rooms: ['Double rooms', 'Single rooms', 'complex rooms'],
+        images: ['www.unsplash.com/umubavu', 'www.gettyimages/umubavuhotel'],
+        hotelemail: 'five@yahoo.com'
+      })
+      .end((err, res) => {
+        expect(res.status).to.equal(201);
+        hotelId = res.body.hotel.hotelId;
+        done();
+      });
+  });
+  it('should return 500 if hotel deleted but rooms not deleted', (done) => {
+    chai
+      .request(app)
+      .delete('/hotels/1')
+      .set('authorization', token)
+      .end((err, res) => {
+        expect(res.status).to.equal(500);
+        done();
+      });
+  });
+});

--- a/src/tests/manager.test.js
+++ b/src/tests/manager.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-/* eslint-disable object-curly-newline */
 import { use, request, expect } from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../app';
@@ -11,7 +9,6 @@ const { ADMIN_PASSWORD } = process.env;
 let tokenAdmin = '',
   tokenManager = '',
   tokenUser = '',
-  token = '',
   userId = '';
 
 describe('MANAGER Endpoints', () => {
@@ -307,7 +304,7 @@ describe('MANAGER Endpoints', () => {
                         });
 
                         describe('PUT/:id /manager/requests/:id', () => {
-                          it('Manager should update a request', async () => {
+                          it('Manager should reject a  request', async () => {
                             const res = await request(app)
                               .put('/manager/requests/1')
                               .set('authorization', tokenManager)
@@ -353,7 +350,7 @@ describe('MANAGER Endpoints', () => {
                               .set('authorization', tokenManager)
                               .send({
                                 _userId: userId,
-                                _managerId: 12
+                                _managerId: 1
                               });
                             expect(res).to.have.status(403);
                           });
@@ -389,6 +386,17 @@ describe('MANAGER Endpoints', () => {
                                 _managerId: 2
                               });
                             expect(res).to.have.status(404);
+                          });
+                          it('Manager should approve a request', async () => {
+                            const res = await request(app)
+                              .put('/manager/requests/1')
+                              .set('authorization', tokenManager)
+                              .send({
+                                requestStatus: 'APPROVED'
+                              });
+                            expect(res).to.have.status(200);
+                            expect(res.body).to.have.property('message');
+                            expect(res.body.message).to.match(/Request updated successfully!/i);
                           });
                         });
                       });

--- a/src/tests/room.test.js
+++ b/src/tests/room.test.js
@@ -1,7 +1,7 @@
 process.env.NODE_ENV = 'test';
 
 import model from '../database/models';
-import app from "../app";
+import { app } from "../app";
 import chai from "chai";
 import chaiHttp from "chai-http";
 const { expect } = chai;

--- a/src/tests/search.test.js
+++ b/src/tests/search.test.js
@@ -1,6 +1,6 @@
 import chai from "chai";
 import http from "chai-http";
-import app from '../app';
+import { app } from '../app';
 import jwt from "jsonwebtoken";
 import "dotenv/config";
 import model from "../database/models";


### PR DESCRIPTION
#### What does this PR do?

- Enable notification on actioned request

#### Description of Task to be completed? 

- Setup `socket.io`
- Add notification model
- Associate request model with notification model
- Associate notification model with user model
- Revise manager controller to enable notification on action made on request
- Revise request controller to enable notification upon request creation
- Mock frontend to show how notifications will look
- Update manager controller tests to include notifications upon action

#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch **`ft-actioned-request-notification-#175743330`**

- Then run **`npm install`** to install all dependencies

- Run **`npm start`** to start the server

- In your default browser navigate to **`http://localhost:5000`** 
- Use postman try to randomly pick `id` of any user assigned to you and then try to action on his/her request, you should see in the browser a notification.

#### Any background context you want to provide?

- To see the notification you have to submit the `id` of user just to join notifications. 
- You also have to login as manager so as to action on request by either approving or rejecting

#### What are the relevant Pivotal Tracker stories?

- [#175743330](https://www.pivotaltracker.com/n/projects/2476678/stories/175743330)

#### Screenshots (if appropriate)

<img width="735" alt="Screen Shot 2021-02-06 at 09 46 06" src="https://user-images.githubusercontent.com/54619678/107112506-bf443700-6860-11eb-9689-924fce2729b5.png"> 

<img width="589" alt="Screen Shot 2021-02-06 at 09 46 29" src="https://user-images.githubusercontent.com/54619678/107112510-c9663580-6860-11eb-99f7-f45e31218718.png">


#### Questions:

- N/A
