### PR TITLE
Add search functionality request#175743332

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ import facilityRoute from './routes/Facility';
 import reactionRoutes from './routes/reaction';
 import commentRoutes from './routes/comment';
 import ratingRoutes from './routes/rating';
-
+import searchRoutes from "./routes/searchRoute";
 
 dotenv.config();
 
@@ -77,5 +77,6 @@ app.use('/facility', facilityRoute);
 app.use('/facility', reactionRoutes);
 app.use(commentRoutes);
 app.use('/facility', ratingRoutes);
+app.use(searchRoutes);
 
 export default app;

--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -1,0 +1,58 @@
+
+import model from "../database/models";
+import Sequelize from 'sequelize'
+
+const Op = Sequelize.Op;
+
+const returnQueries = (query) =>{
+    const queries = [];
+    for (const key in query) {
+      const value = query[key];
+      
+      if (key === 'requestStatus' || key === 'requesterName' || key === 'hotelName' || key === 'location' || key === 'roomType' ) queries.push({ [key]: { [Op.iLike]: `%${value}%` } }) ;
+      else queries.push( { [key]: value })
+      
+    }
+    return queries;
+}
+
+export const searchRequest = async (req, res) => {
+  try {  
+    const queries = returnQueries(req.query);
+    const { id } = req.userData;
+    const Request = await model.request.findAll({
+      where: { idUser:id, [Op.and]: queries,  },
+      include:[
+        {
+          model:model.User,
+          as:"Requester",
+        }
+      ]
+    });
+   
+    res.status(200).json({ Request });
+  } catch (error) {
+    res.status(400).json({message:error.message});
+  }
+  };
+
+  export const managerSearchRequestForRequester = async (req, res) => {
+    try {
+      
+      const { id } = req.userData;
+      const queries = returnQueries(req.query);
+  
+      const Request = await model.request.findAll({
+        where: { [Op.and]: queries,  },
+        include:[
+          {
+            model:model.User,
+            as:"Requester",
+          }
+        ]
+      });
+      res.status(200).json({ Request: Request.filter((request)=> (request.idUser !== id && request.Requester.managerId === id ) )});
+    } catch (error) {
+      res.status(400).json({message:error.message});
+    }
+  };

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -10,6 +10,10 @@ module.exports = (sequelize, DataTypes) => {
         onDelete: 'CASCADE',
         onUpdate: 'CASCADE'
       });
+      request.belongsTo(models.User, {
+        as:'Requester',
+        foreignKey:'idUser'
+      });
     }
   }
   request.init({

--- a/src/routes/searchRoute.js
+++ b/src/routes/searchRoute.js
@@ -1,0 +1,107 @@
+import { Router } from "express";
+import {searchRequest,managerSearchRequestForRequester,managerSearchRequestForOwnRequest } from "../controllers/searchController";
+import auth from "../middlewares/check-auth";
+import { authManager } from '../middlewares/authManager';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /requests/search:
+ *    get:
+ *      summary: Search own requests as requester
+ *      tags: [Search]
+ *      parameters:
+ *        - in: query
+ *          name: idRoom
+ *          schema:
+ *            type: integer
+ *          description: id for room
+ *        - in: query
+ *          name: dateStart
+ *          schema:
+ *            type: date
+ *          description: checkin date
+ *        - in: query
+ *          name: dateEnd
+ *          schema:
+ *            type: date
+ *          description: checkout date 
+ *        - in: query
+ *          name: requestStatus
+ *          schema:
+ *            type: string
+ *          description: request status
+ *      responses:
+ *        "200":
+ *          description: search successfull
+ */
+router.get("/request/search",auth,searchRequest);
+
+/**
+ * @swagger
+ * /requests/search/requester:
+ *    get:
+ *      summary: Search requests as manager
+ *      tags: [Search]
+ *      parameters:
+ *        - in: query
+ *          name: idRoom
+ *          schema:
+ *            type: integer
+ *          description: id for room
+ *        - in: query
+ *          name: dateStart
+ *          schema:
+ *            type: date
+ *          description: checkin date
+ *        - in: query
+ *          name: dateEnd
+ *          schema:
+ *            type: date
+ *          description: checkout date 
+ *        - in: query
+ *          name: requestStatus
+ *          schema:
+ *            type: string
+ *          description: request status
+ *      responses:
+ *        "200":
+ *          description: search successfull
+ */
+router.get("/request/search/requester",auth, authManager, managerSearchRequestForRequester);
+
+/**
+ * @swagger
+ * /requests/search/manager:
+ *    get:
+ *      summary: Search own requests as manager
+ *      tags: [Search]
+ *      parameters:
+ *        - in: query
+ *          name: idRoom
+ *          schema:
+ *            type: integer
+ *          description: id for room
+ *        - in: query
+ *          name: dateStart
+ *          schema:
+ *            type: date
+ *          description: checkin date
+ *        - in: query
+ *          name: dateEnd
+ *          schema:
+ *            type: date
+ *          description: checkout date 
+ *        - in: query
+ *          name: requestStatus
+ *          schema:
+ *            type: string
+ *          description: request status
+ *      responses:
+ *        "200":
+ *          description: search successfull
+ */
+router.get("/request/search/manager",auth, authManager, searchRequest);
+
+export default router;

--- a/src/tests/search.test.js
+++ b/src/tests/search.test.js
@@ -1,0 +1,127 @@
+import chai from "chai";
+import http from "chai-http";
+import app from '../app';
+import jwt from "jsonwebtoken";
+import "dotenv/config";
+import model from "../database/models";
+import Sequelize from 'sequelize'
+
+const Op = Sequelize.Op;
+
+chai.use(http);
+const expect = chai.expect;
+
+describe("search component", () =>{
+    const token = jwt.sign({ id: 1 }, process.env.JWT_KEY, { expiresIn: "1h" });
+
+    it("should search request", async() => {
+        const user = await model.User.create({
+            firstname: "Maliza",
+            lastname: "Constantine",
+            telephone: "",
+            email: "malizacoco4@gmail.com",
+            password: "1234567$#8",
+            gender: "Female",
+            age: 23,
+            identification_type: "",
+            identification_number: "",
+            user_image: "",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+     
+          const res = await chai
+            .request(app)
+            .get(`/request/search?idRoom=100&requestStatus=d`)
+            .set("authorization", `Bearer ${token}`);
+          expect(res).to.have.status(200);
+          after (async () => {
+            await model.User.destroy({where:{id: user.id}})
+          })
+    });
+    it("should failed to search request", async() => {
+        const user = await model.User.create({
+            firstname: "Maliza",
+            lastname: "Constantine",
+            telephone: "",
+            email: "malizacoco4@gmail.com",
+            password: "1234567$#8",
+            gender: "Female",
+            age: 23,
+            identification_type: "",
+            identification_number: "",
+            user_image: "",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+     
+          const res = await chai
+            .request(app)
+            .get(`/request/search?idRoom=jjjjjj&requestStatus=d`)
+            .set("authorization", `Bearer ${token}`);
+          expect(res).to.have.status(400);
+          after (async () => {
+            await model.User.destroy({where:{id: user.id}})
+          })
+    });
+    it("should manager search request for requester ", async() => {
+
+        const role = await model.userRoles.findOne({where:{name: 'MANAGER',}});
+        const user = await model.User.create({
+            firstname: "Maliza",
+            lastname: "Constantine",
+            telephone: "",
+            email: "malizacoco4@gmail.com",
+            password: "1234567$#8",
+            gender: "Female",
+            age: 23,
+            roleId:role.id,
+            identification_type: "",
+            identification_number: "",
+            user_image: "",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+          const tokenManager = jwt.sign({ id: user.id, roleId: user.roleId }, process.env.JWT_KEY, { expiresIn: "1h" });
+
+          const res = await chai
+            .request(app)
+            .get(`/request/search/requester?idRoom=101&requestStatus=d`)
+            .set("authorization", `Bearer ${tokenManager}`);
+       
+          expect(res).to.have.status(200);
+          after (async () => {
+            await model.User.destroy({where:{id: user.id}})
+          })
+    })
+    it("should should manager  if querry which is not there search request for requester ", async() => {
+
+        const role = await model.userRoles.findOne({where:{name: 'MANAGER',}});
+        const user = await model.User.create({
+            firstname: "Maliza",
+            lastname: "Constantine",
+            telephone: "",
+            email: "malizacoco4@gmail.com",
+            password: "1234567$#8",
+            gender: "Female",
+            age: 23,
+            roleId:role.id,
+            identification_type: "",
+            identification_number: "",
+            user_image: "",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          });
+          const tokenManager = jwt.sign({ id: user.id, roleId: user.roleId }, process.env.JWT_KEY, { expiresIn: "1h" });
+
+          const res = await chai
+            .request(app)
+            .get(`/request/search/requester?idRoom=yuuuii&requestStatus=d`)
+            .set("authorization", `Bearer ${tokenManager}`);
+       
+          expect(res).to.have.status(400);
+          after (async () => {
+            await model.User.destroy({where:{id: user.id}})
+          })
+    })
+})


### PR DESCRIPTION
#### What does this PR do?

- Manager and Requester can search request

#### Description of Task to be completed? 

- To search requester must be the authenticated user or manager

#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch **`Search-API#175743332`**

- Then run **`npm install`** to install all dependencies

- Run **`npm start`** to start the server

- In your default browser navigate to **`http://localhost:5000`** 

#### Any background context you want to provide?

- To requester use the endpoint `get` in path **`http://localhost:5000/request/search`** 
- To manager use the endpoint `get` **`http://localhost:5000/request/search/manager`**  
- To manager  to search on requester table use the endpoint `get` **`http://localhost:5000/request/search/requester`**  
- **we will params according to the query** 

#### What are the relevant Pivotal Tracker stories?

- #175743332

#### Screenshots (if appropriate)
- N/A


#### Questions:

- N/A