### PR TITLE
#176788602 ft: User can get request statistics in X time frame

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -105,5 +105,6 @@
 	"Question added successfully!": "Question added successfully!",
 	"Please enter all fields!": "Please enter all fields!",
 	"Question deleted successfully!": "Question deleted successfully!",
-	"Question Id does not exist!": "Question Id does not exist!"
+	"Question Id does not exist!": "Question Id does not exist!",
+	"Invalid time!": "Invalid time!"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -81,5 +81,6 @@
 	"Question found successfully!": "Question trouvée avec succès!",
 	"Question added successfully!": "Question ajoutée avec succès!",
 	"Please enter all fields!": "Veuillez saisir tous les champs!",
-	"Question deleted successfully!": "Question deleted successfully!"
+	"Question deleted successfully!": "Question deleted successfully!",
+	"Invalid time!": "Heure invalide!"
 }

--- a/locales/ki.json
+++ b/locales/ki.json
@@ -67,5 +67,6 @@
 	"Question found successfully!": "Ikibazo cyabonetse neza!",
 	"Question added successfully!": "Ikibazo cyongeweho neza!",
 	"Please enter all fields!": "Nyamuneka andika imirima yose!",
-	"Question deleted successfully!": "Ikibazo cyasibwe neza!"
+	"Question deleted successfully!": "Ikibazo cyasibwe neza!",
+	"Invalid time!": "Igihe kitemewe!"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -71,5 +71,6 @@
 	"Question found successfully!": "Swali limepatikana kwa mafanikio!",
 	"Question added successfully!": "Swali limeongezwa kwa mafanikio!",
 	"Please enter all fields!": "Tafadhali ingiza sehemu zote!",
-	"Question deleted successfully!": "Swali limefutwa kwa mafanikio!"
+	"Question deleted successfully!": "Swali limefutwa kwa mafanikio!",
+	"Invalid time!": "Wakati batili!"
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
     "mocha-lcov-reporter": "^1.3.0",
+    "moment": "^2.29.1",
     "multer": "^1.4.2",
     "nodemailer": "^6.4.17",
     "nodemailer-sendgrid": "^1.0.3",

--- a/src/controllers/reqStatisticsController.js
+++ b/src/controllers/reqStatisticsController.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable require-jsdoc */
+import requestHelper from '../utils/requestHelper';
+import reqStatistics from '../helpers/reqStatistics';
+import requestService from '../services/requestService';
+import userService from '../services/userService';
+
+const { findAllRequestsByUserId } = requestHelper,
+  { filterRequests } = reqStatistics,
+  { findUserByManagerId } = userService,
+  { findRequestByManagerId, requestLength } = requestService;
+
+export default class reqStatisticsController {
+  static async userGetReqStats(req, res) {
+    try {
+      const { time } = req.query,
+        { id } = req.userData,
+
+        existingRequest = await findAllRequestsByUserId(id);
+
+      const allRequests = await filterRequests(time, existingRequest),
+
+        nberRequests = await requestLength(allRequests);
+
+      res.status(200).json({ message: res.__('All requests found successfully!'), nberRequests, allRequests });
+    } catch (error) {
+      return res.status(500).json({ error: error.message });
+    }
+  }
+
+  static async managerGerGetReqStats(req, res) {
+    try {
+      const { time } = req.query,
+        { id } = req.userData,
+
+        // finding all users with a provided managerId
+        existingUsers = await findUserByManagerId(id),
+
+        // mapping users Id with the aforementioned managerId
+        userIds = existingUsers.map((users) => users.id),
+
+        existingRequest = await findRequestByManagerId(userIds);
+
+      const allRequests = await filterRequests(time, existingRequest),
+
+        nberRequests = await requestLength(allRequests);
+
+      res.status(200).json({ message: res.__('All requests found successfully!'), nberRequests, allRequests });
+    } catch (error) {
+      return res.status(500).json({ error: error.message });
+    }
+  }
+}

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
@@ -11,8 +12,8 @@ module.exports = (sequelize, DataTypes) => {
         onUpdate: 'CASCADE'
       });
       request.belongsTo(models.User, {
-        as:'Requester',
-        foreignKey:'idUser'
+        as: 'Requester',
+        foreignKey: 'idUser'
       });
       request.hasMany(models.Notification, {
         foreignKey: 'requestId',

--- a/src/helpers/reqStatistics.js
+++ b/src/helpers/reqStatistics.js
@@ -1,0 +1,20 @@
+/* eslint-disable require-jsdoc */
+import moment from 'moment';
+
+export default class reqStatistics {
+  static async filterRequests(time, existingRequest) {
+    const today = new Date();
+
+    today.setDate(today.getDate() - time);
+
+    const desiredtime = today,
+      year = desiredtime.getFullYear(),
+      month = desiredtime.getMonth() + 1,
+      date = desiredtime.getDate(),
+
+      desiredDay = `${year}-${month}-${date}`,
+
+      allRequests = existingRequest.filter((item) => (item ? (moment(`${(item.createdAt).toDateString()}`).isSameOrAfter(desiredDay)) : false));
+    if (allRequests) return allRequests;
+  }
+}

--- a/src/middlewares/check-auth.js
+++ b/src/middlewares/check-auth.js
@@ -1,17 +1,16 @@
 const jwt = require('jsonwebtoken');
-require("dotenv").config();
+require('dotenv').config();
 
 module.exports = (req, res, next) => {
-    
-    try {
-        const token = req.headers.authorization.split(" ")[1];
-        const decoded = jwt.verify(token, process.env.JWT_KEY);
-        req.userData = decoded;
-        next();
-    } catch (error) {
-        return res.status(401).json({
-            message: 'Auth failed',
-            
-        });
-    }
+  try {
+    const token = req.headers.authorization.split(' ')[1];
+    const decoded = jwt.verify(token, process.env.JWT_KEY);
+    req.userData = decoded;
+    next();
+  } catch (error) {
+    return res.status(401).json({
+      message: 'Auth failed',
+
+    });
+  }
 };

--- a/src/middlewares/requestValidation.js
+++ b/src/middlewares/requestValidation.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable import/prefer-default-export */
 import Joi from 'joi';
 
@@ -36,6 +37,17 @@ export const approveRequestValidation = (req, res, next) => {
 
   const { error } = schema.validate(req.body);
   if (error) return res.status(400).json({ message: error.details[0].message });
+
+  return next();
+};
+
+export const reqStatisticsValidation = (req, res, next) => {
+  const schema = Joi.number().min(0),
+    { time } = req.query;
+
+  const { error } = req.method === 'GET' ? schema.validate(time) : null;
+
+  if (error) return res.status(403).json({ message: res.__('Invalid time!') });
 
   return next();
 };

--- a/src/routes/managerRoutes.js
+++ b/src/routes/managerRoutes.js
@@ -1,15 +1,16 @@
+/* eslint-disable object-curly-newline */
 /* eslint-disable import/no-cycle */
 import { Router } from 'express';
 import { authManager } from '../middlewares/authManager';
-import { approveRequestValidation } from '../middlewares/requestValidation';
+import { approveRequestValidation, reqStatisticsValidation } from '../middlewares/requestValidation';
 import requestController from '../controllers/requestController';
 import managerController from '../controllers/managerController';
+import reqStatisticsController from '../controllers/reqStatisticsController';
 
 const router = new Router(),
   { createRequest } = requestController,
-  {
-    getAllRequests, getOneRequest, updateRequest, assignManagerId
-  } = managerController;
+  { getAllRequests, getOneRequest, updateRequest, assignManagerId } = managerController,
+  { managerGerGetReqStats } = reqStatisticsController;
 
 /**
  * @swagger
@@ -23,6 +24,25 @@ const router = new Router(),
  *        description: Requests are displayed successfuly.
 */
 router.get('/requests', authManager, getAllRequests);
+
+/**
+ * @swagger
+ * /manager/requests/stats:
+ *  get:
+ *    tags: [Manager]
+ *    summary: Manager can get request statistics in X time.
+ *    description: Manager can get request statistics in X time from database.
+ *    parameters:
+ *      - in: query
+ *        name: time
+ *        schema:
+ *          type: integer
+ *        description: days from today
+ *    responses:
+ *      '200':
+ *        description: Requests found successfully.
+*/
+router.get('/requests/stats', authManager, reqStatisticsValidation, managerGerGetReqStats);
 
 /**
  * @swagger

--- a/src/routes/requestRoute.js
+++ b/src/routes/requestRoute.js
@@ -1,13 +1,16 @@
+/* eslint-disable import/no-cycle */
 /* eslint-disable object-curly-newline */
 /* eslint-disable max-len */
 import { Router } from 'express';
 import authRequest from '../middlewares/check-auth';
-import { createRequestValidation, updateRequestValidation } from '../middlewares/requestValidation';
+import { createRequestValidation, updateRequestValidation, reqStatisticsValidation } from '../middlewares/requestValidation';
 import requestController from '../controllers/requestController';
+import reqStatisticsController from '../controllers/reqStatisticsController';
 
 const router = Router();
 
-const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteRequest } = requestController;
+const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteRequest } = requestController,
+  { userGetReqStats } = reqStatisticsController;
 
 /**
  * @swagger
@@ -21,6 +24,25 @@ const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteReque
  *        description: Requests are displayed successfuly.
 */
 router.get('/', authRequest, getAllRequests);
+
+/**
+ * @swagger
+ * /requests/stats:
+ *  get:
+ *    tags: [Request Accommodation]
+ *    summary: Authenticated user can get request statistics in X time.
+ *    description: Authenticated user can get request statistics in X time from database.
+ *    parameters:
+ *      - in: query
+ *        name: time
+ *        schema:
+ *          type: integer
+ *        description: days from today
+ *    responses:
+ *      '200':
+ *        description: Requests found successfully.
+*/
+router.get('/stats', authRequest, reqStatisticsValidation, userGetReqStats);
 
 /**
  * @swagger

--- a/src/tests/manager.test.js
+++ b/src/tests/manager.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 import { use, request, expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { app } from '../app';
@@ -10,7 +11,8 @@ const { ADMIN_PASSWORD } = process.env;
 let tokenAdmin = '',
   tokenManager = '',
   tokenUser = '',
-  userId = '';
+  userId = '',
+  time;
 
 describe('MANAGER Endpoints', () => {
   describe('Signin Super Admin', () => {
@@ -241,6 +243,26 @@ describe('MANAGER Endpoints', () => {
                             expect(res).to.have.status(400);
                             expect(res.body).to.have.property('error');
                             expect(res.body.message).to.match(/undefined/i);
+                          });
+                        });
+
+                        describe('GET /manager/requests/stats', () => {
+                          it('Manager should get requests statistics', async () => {
+                            time = 30;
+                            const res = await request(app)
+                              .get(`/manager/requests/stats?time=${time}`)
+                              .set('authorization', tokenManager);
+
+                            expect(res).to.have.status(200);
+                          });
+
+                          it('Manager should not get requests statistics', async () => {
+                            time = -30;
+                            const res = await request(app)
+                              .get(`/manager/requests/stats?time=${time}`)
+                              .set('authorization', tokenManager);
+
+                            expect(res).to.have.status(403);
                           });
                         });
 

--- a/src/tests/request.test.js
+++ b/src/tests/request.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 import { use, request, expect } from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../app';
@@ -9,7 +10,8 @@ const { ADMIN_PASSWORD } = process.env;
 
 let tokenManager = '',
   tokenUser = '',
-  userId = '';
+  userId = '',
+  time;
 
 describe('REQUEST Endpoints', () => {
   describe('Signin Manager', () => {
@@ -153,6 +155,32 @@ describe('REQUEST Endpoints', () => {
                     .get('/requests')
                     .set('authorization', tokenUser);
                   expect(res).to.have.status(200);
+                });
+
+                describe('GET /requests/stats', () => {
+                  it('Should get request statistics', async () => {
+                    time = 30;
+                    const res = await request(app)
+                      .get(`/requests/stats?time=${time}`)
+                      .set('authorization', tokenUser);
+                    expect(res).to.have.status(200);
+                  });
+
+                  it('Should not get request statistics', async () => {
+                    time = -1;
+                    const res = await request(app)
+                      .get(`/requests/stats?time=${time}`)
+                      .set('authorization', tokenUser);
+                    expect(res).to.have.status(403);
+                  });
+
+                  it('Should not get request statistics', async () => {
+                    time = '-10';
+                    const res = await request(app)
+                      .get(`/requests/stats?time=${time}`)
+                      .set('authorization', tokenUser);
+                    expect(res).to.have.status(403);
+                  });
                 });
 
                 describe('GET/:id /requests/:id', () => {


### PR DESCRIPTION
#### What does this PR do?
- Allows a user or manager to get request statistics in X time frame.

#### Description of Task to be completed? 
- Allows a user or manager to get request statistics in X time frame.
- Implement API documentation by using Swagger.
- Test all APIs by using mocha/chai.

#### How should this be manually tested?
- Clone the repository.

- In your home directory move into the cloned folder by cd this branch **`ft-request-stats-#176788602`**.

- Run **`npm migrate:reset`** to create tables.

- Run **`npm seed`** to insert some dummy data.

- Run **`npm start`** to start the server.

- In your default browser navigate to **`http://localhost:5000/api-docs`** to assess the endpoints regarding requests.

- Run **`npm test`** to test the codes.

#### Any background context you want to provide?
- N/A

#### What are the relevant Pivotal Tracker stories?
- [#176788602](https://www.pivotaltracker.com/story/show/176788602)

#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A