### PR TITLE
#175743347 ft(destinations): add most travelled destinations

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -78,5 +78,7 @@
 	"comment with the specified ID does not exists": "comment with the specified ID does not exists",
 	"Request with the specified ID does not exists": "Request with the specified ID does not exists",
 	"Request with the specified ID does not exists ": "Request with the specified ID does not exists ",
-	"comment with the specified ID does not exists ": "comment with the specified ID does not exists "
+	"comment with the specified ID does not exists ": "comment with the specified ID does not exists ",
+	"Most travelled destinations found successfully!": "Most travelled destinations found successfully!",
+	"No destination found!": "No destination found!"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -97,5 +97,7 @@
 	"comment not found such Id:": "commentaire introuvable pour cet identifiant",
 	"Comment deleted successfully!": "Commentaire supprimé avec succès!",
 	"comment with the specified ID does not exists": "le commentaire avec l'ID spécifié n'existe pas",
-	"Request with the specified ID does not exists": "La demande avec l'ID spécifié n'existe pas"
+	"Request with the specified ID does not exists": "La demande avec l'ID spécifié n'existe pas",
+	"Most travelled destinations found successfully!": "Les destinations les plus visitées ont été trouvées avec succès!",
+	"No destination found!": "Aucune destination trouvée!"
 }

--- a/locales/ki.json
+++ b/locales/ki.json
@@ -82,5 +82,7 @@
 	"comment not found such Id": "igitekerezo nticyabonetse Id",
 	"Comment deleted successfully!": "Igitekerezo cyasibwe neza!",
 	"comment with the specified ID does not exists": "igitekerezo hamwe nindangamuntu isobanutse ntikibaho",
-	"Request with the specified ID does not exists": "Gusaba hamwe nindangamuntu isobanutse ntabwo ibaho"
+	"Request with the specified ID does not exists": "Gusaba hamwe nindangamuntu isobanutse ntabwo ibaho",
+	"Most travelled destinations found successfully!": "Ingendo nyinshi zagiye ziboneka neza!",
+	"No destination found!": "Icyerekezo ntikiboneka"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -86,5 +86,7 @@
 	"comment not found such Id": "maoni hayakupatikana kama Id",
 	"Comment deleted successfully!": "Maoni yamefutwa !",
 	"comment with the specified ID does not exists": "maoni na kitambulisho kilichoainishwa hayapo",
-	"Request with the specified ID does not exists": "Ombi na kitambulisho kilichoainishwa haipo"
+	"Request with the specified ID does not exists": "Ombi na kitambulisho kilichoainishwa haipo",
+	"Most travelled destinations found successfully!": "Sehemu nyingi za kusafiri zimepatikana kwa mafanikio!",
+	"No destination found!": "Hakuna marudio yaliyopatikana!"
 }

--- a/src/helpers/countOccurance.js
+++ b/src/helpers/countOccurance.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-sequences */
+/* eslint-disable no-plusplus */
+/* eslint-disable no-return-assign */
+
+export default (arr) => {
+  const counted = arr.reduce((prev, curr) => (prev[curr] = ++prev[curr] || 1, prev), {});
+  return counted;
+};
+
+export const sortByHighest = (obj) => Object.entries(obj).sort((a, b) => b[1] - a[1]);

--- a/src/routes/requestRoute.js
+++ b/src/routes/requestRoute.js
@@ -9,9 +9,8 @@ import reqStatisticsController from '../controllers/reqStatisticsController';
 
 const router = Router();
 
-const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteRequest } = requestController,
+const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteRequest, mostTravelledDestination } = requestController,
   { userGetReqStats } = reqStatisticsController;
-
 /**
  * @swagger
  * /requests:
@@ -24,7 +23,22 @@ const { getAllRequests, getOneRequest, createRequest, updateRequest, deleteReque
  *        description: Requests are displayed successfuly.
 */
 router.get('/', authRequest, getAllRequests);
-
+/**
+ * @swagger
+ * /requests/destinations:
+ *  get:
+ *    tags: [Request Accommodation]
+ *    summary: Get most travelled destinations.
+ *    description: Authenticated users can get most travelled destinations.
+ *    responses:
+ *      '200':
+ *        description: Most travelled destinations found successfully!
+ *      '404':
+ *        description: No destination found!
+ *      '500':
+ *        description: Internal server error!
+*/
+router.get('/destinations', authRequest, mostTravelledDestination);
 /**
  * @swagger
  * /requests/stats:

--- a/src/tests/request.test.js
+++ b/src/tests/request.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-named-as-default */
 import { use, request, expect } from 'chai';
 import chaiHttp from 'chai-http';
-import app from '../app';
+import { app } from '../app';
 import model from '../database/models';
 
 use(chaiHttp);
@@ -155,6 +155,15 @@ describe('REQUEST Endpoints', () => {
                     .get('/requests')
                     .set('authorization', tokenUser);
                   expect(res).to.have.status(200);
+                });
+                describe('GET /requests/destinations', () => {
+                  it('Should most travelled destinations', async () => {
+                    const res = await request(app)
+                      .get('/requests/destinations')
+                      .set('authorization', tokenUser);
+                    expect(res).to.have.status(200);
+                    expect(res.body.message).to.match(/Most travelled destinations found successfully!/i);
+                  });
                 });
 
                 describe('GET /requests/stats', () => {


### PR DESCRIPTION
#### What does this PR do?

- Implement most travelled destinations

#### Description of Task to be completed? 

- Get all requests with approved status
- Filter locations of those requests
- Display found request from the highest frequency

#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch **`ft-most-travelled-destinations-#175743347`**

- Then run **`npm install`** to install all dependencies

- Run **`npm start`** to start the server

- Using postman  hit this endpoint **`http://localhost:5000/requests/destinations`** 

#### Any background context you want to provide?

- To be able to see most travelled destinations you need first to login 

#### What are the relevant Pivotal Tracker stories?

- [#175743347](https://www.pivotaltracker.com/n/projects/2476678/stories/175743347)

#### Screenshots (if appropriate)

<img width="1112" alt="Screen Shot 2021-02-14 at 14 29 25" src="https://user-images.githubusercontent.com/54619678/107876832-32892100-6ed1-11eb-8de9-9957b2c29d89.png">



#### Questions:

- N/A
