### PR TITLE
#177096172 bug(emails): fix verify/reset emails

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,7 @@
 	"Facility re-unliked": "Facility re-unliked",
 	"Roles found in system": "Roles found in system",
 	"Role created successfully!": "Role created successfully!",
-	"User registered": "User registered",
+	"You are registered, Please check your email to verify your account": "You are registered, Please check your email to verify your account",
 	"Role assigned successfully": "Role assigned successfully",
 	"No role found with such id": "No role found with such id",
 	"Role found in the system": "Role found in the system",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,7 +1,7 @@
 {
 	"Welcome to barefoot nomad": "Bienvenue chez barefoot nomad",
 	"Email already registered": "Email déjà enregistré",
-	"User registered": "Utilisateur enregistré",
+	"You are registered, Please check your email to verify your account": "Vous êtes inscrit, veuillez vérifier votre messagerie pour vérifier votre compte",
 	"Authentication failed. User not found.": "Authentification échouée. Utilisateur non trouvé.",
 	"Authentication failed. Wrong password.": "Authentification échouée. Mauvais mot de passe.",
 	"Error": "Erreur",

--- a/locales/ki.json
+++ b/locales/ki.json
@@ -1,7 +1,7 @@
 {
 	"Welcome to barefoot nomad": "Murakaza neza kuri barefoot nomad",
 	"Email already registered": "Imeri yamaze kwiyandikisha",
-	"User registered": "Umukoresha yiyandikishije",
+	"You are registered, Please check your email to verify your account": "Wiyandikishije, Nyamuneka reba imeri yawe kugirango urebe konti yawe",
 	"Authentication failed. User not found.": "Kwemeza byarananiranye. Umukoresha ntabwo yabonetse.",
 	"Authentication failed. Wrong password.": "Kwemeza byarananiranye. Ijambobanga ritari ryo.",
 	"Error": "Ikosa",

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -1,7 +1,7 @@
 {
 	"Welcome to barefoot nomad": "Karibu kwa barefoot nomad",
 	"Email already registered": "Barua pepe tayari imesajiliwa",
-	"User registered": "Mtumiaji amesajiliwa",
+	"You are registered, Please check your email to verify your account": "Umesajiliwa, Tafadhali angalia barua pepe yako ili kuthibitisha akaunti yakount",
 	"Authentication failed. User not found.": "",
 	"Authentication failed. Wrong password.": "Uthibitishaji umeshindwa. Mtumiaji hajapatikana.",
 	"Error": "Kosa",

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -37,7 +37,7 @@ export const signup = (req, res) => {
           const token = jwt.sign(JSON.parse(JSON.stringify(user1)), process.env.JWT_KEY, { expiresIn: '1h' });
           jwt.verify(token, process.env.JWT_KEY, () => {});
           res.status(201).json({
-            message: res.__('User registered'),
+            message: res.__('You are registered, Please check your email to verify your account'),
             user_details: user1,
             token: `JWT ${token}`
           });
@@ -140,7 +140,7 @@ export const verifyUser = async (req, res) => {
       res.status(400).send(template(user.firstname, null, 'This email is already verified, please click here to login', 'Go to Login'));
     }
     await model.User.update({ isVerified: true }, { where: { email: user.email } });
-    res.status(200).redirect('https://space-barefootnomad.netlify.app');
+    res.status(200).redirect('https://space-barefootnomad.netlify.app/login');
   } catch (error) {
     res.status(400).send(template('User', null, 'Invalid Token, Please signup again', 'Go to Signup'));
   }

--- a/src/middlewares/sendEmail.js
+++ b/src/middlewares/sendEmail.js
@@ -20,7 +20,7 @@ export const sendVerificationEmail = async (firstname, email, token) => {
     html: template(firstname, token),
     mail_settings: {
       sandbox_mode: {
-        enable: true
+        enable: process.env.NODE_ENV === 'test' ? true : false
       }
     },
   };

--- a/src/tests/user.test.js
+++ b/src/tests/user.test.js
@@ -23,7 +23,7 @@ describe('User registration', () => {
       .field('identification_number', '1122020333')
       .then((res) => {
         expect(res).to.have.status(201);
-        expect(res.body.message).to.be.equal('User registered');
+        expect(res.body.message).to.be.equal('You are registered, Please check your email to verify your account');
         expect(res.body.user_details.id).to.exist;
         expect(res.body.user_details.firstname).to.exist;
         expect(res.body.user_details.lastname).to.exist;

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -37,7 +37,7 @@ const mailer = async (emailToSend) => {
         html: data,
         mail_settings: {
           sandbox_mode: {
-            enable: true
+            enable: process.env.NODE_ENV === 'test' ? true : false
           }
         },
       };


### PR DESCRIPTION
#### What does this PR do?

- Fix verify and reset password emails

#### How to reproduce

- Go to signup and try to create account 

#### Expected behavior

- You should see a message telling you to check your email
- You check your email , you should be able to see an email with link to click on to verify your account

#### Received behavior

- After successfully create account you see a message popping up to verify your email
- When you check your emails inbox you can't find that email

#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch **`bg-fix-verify/reset-emails-#177096172`**

- Then run **`npm install`** to install all dependencies

- Run **`npm start`** to start the server

- In your default browser navigate to  sign up or use Postman send request to `PUT` request  to **`http://localhost:5000/user/signup`** 

#### Any background context you want to provide?

- You need to have sendGrid API Key to test this
- You add this `BACKEND_URL` variable in `.env` value will be where your server is running like `http://localhost:5000`

#### What are the relevant Pivotal Tracker stories?

- [#177096172](https://www.pivotaltracker.com/n/projects/2476678/stories/177096172)

#### Screenshots (if appropriate)

- N/A

#### Questions:

- N/A
